### PR TITLE
feat: Change to use issues instead of project items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +164,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -273,6 +294,37 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "time",
+]
+
+[[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = "1"
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+time = { version = "0.3", features = ["parsing"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The missing GitHub Projects dependency visualizer.
 
-Create a mermaid flowchart of dependencies between GitHub Projects Items.  This gives you a map, or [tech tree](https://en.wikipedia.org/wiki/Technology_tree), of tasks, allowing you to see a path to where you want to go.
+Create a mermaid flowchart of dependencies between GitHub issues.  This gives you a map, or [tech tree](https://en.wikipedia.org/wiki/Technology_tree), of tasks, allowing you to see a path to where you want to go.
 
 Make the following obvious:
 
@@ -22,17 +22,25 @@ The visualization is only as good as the input data.  Create dependencies in the
 - Use a [task list](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-task-lists) in the issue.  When a task links to another issue, it's treated as a dependency.
 - Include a line beginning with `Depends on: #123` in the issue.
 
-Create a script with the following, making sure to use your project ID and org name.
+Create a script with the following, making sure to use your org name and repos.
 
 ```shell
-gh project item-list <project-id> \
-  --limit 2000 \
-  --owner MyOrg \
-  --format json \
-  > my_project_items.txt
+gh issue list \
+  --limit 5000 \
+  --repo MyOrg/repo1 \
+  --state all \
+  --json assignees,body,closed,closedAt,comments,id,labels,milestone,number,projectItems,state,title,updatedAt,url \
+  > local/repo1_issues.txt
+gh issue list \
+  --limit 5000 \
+  --repo MyOrg/repo2 \
+  --state all \
+  --json assignees,body,closed,closedAt,comments,id,labels,milestone,number,projectItems,state,title,updatedAt,url \
+  > local/repo2_issues.txt
 cargo run -- map \
   --header "# [My Project](https://github.com/orgs/MyOrg/projects/1/views/1)" \
-  my_project_items.txt \
+  --issues local/repo1_issues.txt \
+  --issues local/repo2_issues.txt \
   | pbcopy
 ```
 
@@ -40,10 +48,8 @@ The diagram is now in your clipboard.  Paste it into an issue, PR description, c
 
 Green boxes are open issues, and purple boxes are closed, just like in GitHub.
 
-To remove items, archive or delete them from the GitHub Project.
-
 ## Filters
 
-Only issues in the project are included.
+To only include issues that are in a GitHub Project, use `--include-project "My Project Title"`.
 
 By default, only issues that have a dependency or are a dependency are included.  To change this, use the `--all` option.

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -12,8 +12,6 @@ pub(crate) struct Node {
     pub url: String,
     pub state: GithubIssueState,
     #[allow(unused)]
-    pub is_in_project: bool,
-    #[allow(unused)]
     pub labels: Vec<String>,
     pub project_titles: IndexSet<String>,
     pub depends_on_urls: IndexSet<String>,

--- a/src/github.rs
+++ b/src/github.rs
@@ -5,56 +5,6 @@ use time::OffsetDateTime;
 type GithubId = String;
 type GithubNumber = NonZeroU32;
 
-#[derive(Debug, Default, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct GithubProjectItemListResult {
-    pub items: Vec<GithubProjectItem>,
-    #[allow(unused)]
-    pub total_count: u32,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct GithubProjectItem {
-    pub content: GithubProjectItemContent,
-    #[allow(unused)]
-    pub id: GithubId,
-    #[allow(unused)]
-    #[serde(default)]
-    pub labels: Vec<String>,
-    #[allow(unused)]
-    #[serde(default)]
-    pub repository: String,
-    #[allow(unused)]
-    #[serde(default)]
-    pub status: String,
-    #[allow(unused)]
-    #[serde(default)]
-    pub title: String,
-}
-
-#[derive(Debug, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct GithubProjectItemContent {
-    #[allow(unused)]
-    #[serde(rename = "type")]
-    pub item_type: String,
-    #[allow(unused)]
-    #[serde(default)]
-    pub body: String,
-    #[allow(unused)]
-    pub title: String,
-    /// The issue or PR number that you use to reference it, e.g. #123.
-    #[allow(unused)]
-    #[serde(default)]
-    pub number: Option<GithubNumber>,
-    #[allow(unused)]
-    #[serde(default)]
-    pub repository: String,
-    #[serde(default)]
-    pub url: String,
-}
-
 #[allow(unused)]
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/github.rs
+++ b/src/github.rs
@@ -5,7 +5,7 @@ use time::OffsetDateTime;
 type GithubId = String;
 type GithubNumber = NonZeroU32;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct GithubProjectItemListResult {
     pub items: Vec<GithubProjectItem>,

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,33 +4,40 @@ type GithubId = String;
 type GithubNumber = NonZeroU32;
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct GithubProjectItemListResult {
     pub items: Vec<GithubProjectItem>,
-    #[serde(rename = "totalCount")]
     #[allow(unused)]
     pub total_count: u32,
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct GithubProjectItem {
     pub content: GithubProjectItemContent,
     #[allow(unused)]
     pub id: GithubId,
+    #[allow(unused)]
     #[serde(default)]
     pub labels: Vec<String>,
+    #[allow(unused)]
     #[serde(default)]
     pub repository: String,
+    #[allow(unused)]
     #[serde(default)]
     pub status: String,
+    #[allow(unused)]
     #[serde(default)]
     pub title: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct GithubProjectItemContent {
     #[allow(unused)]
     #[serde(rename = "type")]
     pub item_type: String,
+    #[allow(unused)]
     #[serde(default)]
     pub body: String,
     #[allow(unused)]
@@ -44,4 +51,142 @@ pub(crate) struct GithubProjectItemContent {
     pub repository: String,
     #[serde(default)]
     pub url: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssue {
+    #[serde(default)]
+    pub assignees: Option<Vec<GithubIssueAssignee>>,
+    #[serde(default)]
+    pub body: String,
+    pub closed: bool,
+    #[serde(default)]
+    pub comments: Option<Vec<GithubIssueComment>>,
+    #[allow(unused)]
+    pub id: GithubId,
+    #[allow(unused)]
+    pub labels: Vec<GithubLabel>,
+    // TODO: Add milestone.
+    // pub milestone: Option<_>,
+    /// The issue or PR number that you use to reference it, e.g. #123.
+    pub number: GithubNumber,
+    pub project_items: Vec<GithubIssueProjectItem>,
+    pub state: GithubIssueState,
+    pub title: String,
+    // TODO: Add updated_at.
+    // pub updated_at: String, // Timestamp
+    pub url: String,
+}
+
+impl GithubIssue {
+    /// Returns the repository part of the URL, e.g.
+    /// "https://github.com/owner/repo", if found.
+    pub fn repository(&self) -> Option<&str> {
+        if let Some((repo, _)) = self.url.split_once("/issues") {
+            return Some(repo);
+        }
+
+        if let Some((repo, _)) = self.url.split_once("/pull") {
+            return Some(repo);
+        }
+
+        None
+    }
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssueAssignee {
+    #[allow(unused)]
+    pub id: GithubId,
+    pub login: String,
+    pub name: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssueComment {
+    #[allow(unused)]
+    pub id: GithubId,
+    pub author: GithubIssueCommentAuthor,
+    pub author_association: String,
+    pub body: String,
+    pub created_at: String, // Timestamp
+    pub includes_created_edit: bool,
+    pub is_minimized: bool,
+    pub minimized_reason: String,
+    // TODO: Add reactions.
+    // pub reaction_groups: Vec<_>,
+    pub url: String,
+    pub viewer_did_author: bool,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssueCommentAuthor {
+    pub login: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubLabel {
+    #[allow(unused)]
+    pub id: GithubId,
+    #[allow(unused)]
+    pub name: String,
+    #[serde(default)]
+    #[allow(unused)]
+    pub description: String,
+    /// Hex color without the # prefix.
+    #[allow(unused)]
+    pub color: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssueProjectItem {
+    /// The status field of the project item.  Since Projects are customizable,
+    /// it's possible for a project to not have a status field.
+    #[serde(default)]
+    pub status: Option<GithubIssueProjectItemStatus>,
+    /// The title of the Project that this is an item of.
+    pub title: String,
+}
+
+#[allow(unused)]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GithubIssueProjectItemStatus {
+    pub option_id: GithubId,
+    /// The name of the status enum, e.g. "Not Started", "In Progress" or "Done".
+    pub name: String,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GithubIssueState {
+    #[default]
+    Open,
+    Closed,
+}
+
+impl<'de> serde::Deserialize<'de> for GithubIssueState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        match s.to_ascii_uppercase().as_str() {
+            "OPEN" => Ok(GithubIssueState::Open),
+            "CLOSED" => Ok(GithubIssueState::Closed),
+            _ => Err(serde::de::Error::custom(format!(
+                "Unexpected value: {s:?}"
+            ))),
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Args, Parser};
 use indexmap::{IndexMap, IndexSet};
 
 use crate::chart::{Flowchart, Node, NodeId};
-use crate::github::GithubProjectItemListResult;
+use crate::github::{GithubIssue, GithubProjectItemListResult};
 
 mod chart;
 mod github;
@@ -32,13 +33,13 @@ struct MapArgs {
     pub header: Option<String>,
     #[arg(long, help = "Mermaid diagram title")]
     pub title: Option<String>,
-    #[arg(
-        long,
-        help = "Case-insensitive status to treat as done.  Can be used multiple times.  Default is \"Done\"."
-    )]
-    pub done_status: Option<Vec<String>>,
     #[arg(long, short, help = "Output all tasks; don't use default filter")]
     pub all: bool,
+    #[arg(
+        long,
+        help = "JSON Issues List stored in a file.  You can use this multiple times."
+    )]
+    pub issues: Option<Vec<PathBuf>>,
     #[arg(
         help = "JSON Project Items List stored in a file.  Use - for STDIN."
     )]
@@ -82,8 +83,35 @@ fn print_dependencies_map(args: MapArgs) -> AppResult<()> {
     let items: GithubProjectItemListResult =
         serde_json::from_str(items_json.as_str())?;
 
-    let done_statuses =
-        args.done_status.unwrap_or_else(|| vec!["done".to_owned()]);
+    let issues: Vec<GithubIssue> = args
+        .issues
+        .unwrap_or_default()
+        .iter()
+        .map(|path| {
+            let issues_json_result = if path == Path::new("-") {
+                // Read from STDIN.
+                let stdin = std::io::stdin().lock();
+                std::io::read_to_string(stdin)
+            } else {
+                // Read from a file.
+                std::fs::read_to_string(path)
+            };
+            let issues_json = match issues_json_result {
+                Ok(i) => i,
+                Err(error) => {
+                    let boxed: Box<dyn std::error::Error> = Box::new(error);
+                    return Err(boxed);
+                }
+            };
+            // Note: It's faster to read the entire file and then parse it.
+            // https://github.com/serde-rs/json/issues/160
+            serde_json::from_str::<Vec<GithubIssue>>(&issues_json)
+                .map_err(|err| Box::new(err).into())
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect();
 
     let mut flowchart =
         Flowchart::new(args.title.unwrap_or_default(), args.all);
@@ -91,43 +119,59 @@ fn print_dependencies_map(args: MapArgs) -> AppResult<()> {
     let mut blocks: IndexMap<NodeId, u32> = IndexMap::default();
 
     let mut id = 1_usize;
-    for item in items.items {
-        // Parse dependencies from the body text.
-        let dependencies = parse::relations(
-            item.content.body.as_str(),
-            item.repository.as_str(),
-            item.title.as_str(),
-        )
-        .map(|relation| relation.target.into_owned());
 
+    for issue in issues {
         // Use a set to dedupe the dependencies.
         let mut depends_on_urls = IndexSet::new();
-        depends_on_urls.extend(dependencies);
 
-        // Increment the count of all the things that block this item.
-        for depends_on_url in &depends_on_urls {
-            let previous_count =
-                blocks.entry(depends_on_url.clone()).or_default();
-            *previous_count = previous_count.saturating_add(1);
+        if let Some(repository) = issue.repository() {
+            // Parse dependencies from the body text.
+            let dependencies = parse::relations(
+                issue.body.as_str(),
+                repository,
+                issue.title.as_str(),
+            )
+            .map(|relation| relation.target.into_owned());
+
+            depends_on_urls.extend(dependencies);
+
+            // Increment the count of all the things that block this item.
+            for depends_on_url in &depends_on_urls {
+                let previous_count =
+                    blocks.entry(depends_on_url.clone()).or_default();
+                *previous_count = previous_count.saturating_add(1);
+            }
+        } else {
+            eprintln!("Warning: Unexpected issue URL; couldn't parse repository: {:?}", issue.url);
         }
-
-        let is_done = done_statuses
-            .iter()
-            .any(|done_status| item.status.eq_ignore_ascii_case(done_status));
 
         let node = Node {
             id: id.to_string(),
-            text: item.title,
-            url: item.content.url,
-            is_done,
-            status: item.status,
-            labels: item.labels,
+            text: issue.title,
+            url: issue.url,
+            state: issue.state,
+            is_in_project: false,
+            labels: issue
+                .labels
+                .iter()
+                .map(|label| label.name.clone())
+                .collect(),
             depends_on_urls,
             blocks_count: 0,
         };
         flowchart.nodes.insert(node.url.clone(), node);
 
         id = id.checked_add(1).expect("Overflowed number of items");
+    }
+
+    for item in items.items {
+        let url = item.content.url;
+        let Some(node) = flowchart.nodes.get_mut(&url) else {
+            // This item is not in the issues.
+            continue;
+        };
+
+        node.is_in_project = true;
     }
 
     // Update nodes to have the count of items they block.

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,7 @@ fn print_dependencies_map(args: MapArgs) -> AppResult<()> {
                 .collect(),
             depends_on_urls,
             blocks_count: 0,
+            updated_at: issue.updated_at,
         };
         flowchart.nodes.insert(node.url.clone(), node);
 


### PR DESCRIPTION
This changes to use issue data instead of project data. This is desirable when project items are archived or deleted, which remove them from the project data. In contrast, issues are rarely if ever deleted.

To continue being able to display only relevant issues, we begin implementing filters. We can now filter issues to a given project. We can now only show closed issues that have been updated in the last N days.

The other consequences of using issue data is that we know with certainty whether an issue is closed. Contrast this with project items which relied on a status field, which can be removed by users. However, the drawback is that we can no longer take advantage of custom project fields. For this, we must rely on parsing issue content text.

Another drawback is that fetching issue data tends to be slower than fetching project data. But I think the trade off is worth it.